### PR TITLE
Fixes in recommendation systems

### DIFF
--- a/priporocanje.tex
+++ b/priporocanje.tex
@@ -230,13 +230,19 @@ Z matrikami P in Q lahko izračunamo približek ocene za stvar $i$ uporabnika $u
   \hat{r_{ui}}={\bf p}_u^T {\bf q}_i = \sum_{k=1}^K p_{uk} q_{ki}
 \end{equation}
 
-Za ocene iz učne množice $r_{ui}$ bi želeli, da je ta približek čim boljši, oziroma da je napaka, ki jo s tem približkom naredimo, čim manjša. Izračunajmo kvadrat napake za oceno stvari $i$ uporabnika $u$ in ga pomnožimo z $1\over 2$, da se nam kasneje pokrajša dvojka pri odvajanju:
+Za ocene iz učne množice $r_{ui}$ bi želeli, da je ta približek čim boljši, oziroma da je napaka, ki jo s tem približkom naredimo, čim manjša. Izračunajmo kvadrat napake za oceno stvari $i$ uporabnika $u$:
 %
 \begin{equation}\label{eq:fact-error}
-  e_{ui}^2 = {1\over 2}(r_{ui}-\hat{r}_{ui})^2
+  e_{ui}^2 = (r_{ui}-\hat{r}_{ui})^2
 \end{equation}
 %
-Želeli bi poiskati taki matriki $P$ in $Q$, kjer so te napake čim manjše. Ker bomo pri numeričnem iskanju teh matrik v vsaki iteraciji obravnavali natančno enega med učnimi primeri (torej $r_{ui}$ za določen par $(u,i)\in\tau$), potrebujemo izračunati gradient napake za vsakega od parametrov modela. Naš model sta matriki P in Q, vrednosti parametrov modela pa vsi njuni elementi $p_{uk}$ in $q_{ki}$. V enačbo za napako (enačba~\ref{eq:fact-error}) vstavimo izraz iz enačbe~\ref{eq:rui-latent} in odvajajmo:
+Želeli bi poiskati taki matriki $P$ in $Q$, kjer so te napake čim manjše. Ker bomo pri numeričnem iskanju teh matrik v vsaki iteraciji obravnavali natančno enega med učnimi primeri (torej $r_{ui}$ za določen par $(u,i)\in\tau$), potrebujemo izračunati gradient napake za vsakega od parametrov modela. Naš model sta matriki P in Q, vrednosti parametrov modela pa vsi njuni elementi $p_{uk}$ in $q_{ki}$. V enačbo za napako (enačba~\ref{eq:fact-error}) vstavimo izraz iz enačbe~\ref{eq:rui-latent}:
+%
+\begin{equation}
+  e_{ui}^2 = \frac{1}{2}\left(r_{ui}-\sum_{k=1}^K p_{uk} q_{ki}\right)^2.
+\end{equation}
+%
+Enačbo smo pomnožili z $\frac{1}{2}$ tako, da se nam dvojka kasneje pri odvajajnju pokrajša. Odvod enačbe je seledeč:
 %
 \begin{eqnarray}
   \frac{\partial e_{ui}^2}{\partial p_{uk}} & = & -e_{ui}q_{ki} \\

--- a/priporocanje.tex
+++ b/priporocanje.tex
@@ -215,7 +215,7 @@ Matrika $\rm P$ je matrika uporabniških profilov v latentnem prostoru filmov, t
 \begin{figure}[htbp]
 \begin{center}
 \includegraphics[width=7cm]{slike/latentni-faktorji.pdf}
-\caption{Predstavitev uporabnika $u$ z latetnim profilom ${\bf p}_u$ in stvari $i$ z latentnim profilom ${\bf q}_i$. Skalarni produkt latentnih profilov nam da približek za oceno stvari $i$ uporabnika $u$, torej $\hat{r_{ui}}={\bf p}_u {\bf q}_i$.}
+\caption{Predstavitev uporabnika $u$ z latetnim profilom ${\bf p}_u$ in stvari $i$ z latentnim profilom ${\bf q}_i$. Skalarni produkt latentnih profilov nam da približek za oceno stvari $i$ uporabnika $u$, torej $\hat{r_{ui}}={\bf p}_u^T {\bf q}_i$.}
 \label{f:latentni-faktorji}
 \end{center}
 \end{figure}
@@ -227,7 +227,7 @@ Razcep matrike R na matriki P in Q bomo poiskali tako, da bosta matriki P in Q p
 Z matrikami P in Q lahko izračunamo približek ocene za stvar $i$ uporabnika $u$, ki je:
 %
 \begin{equation}\label{eq:rui-latent}
-  \hat{r_{ui}}={\bf p}_u {\bf q}_i = \sum_{k=1}^K p_{uk} q_{ki}
+  \hat{r_{ui}}={\bf p}_u^T {\bf q}_i = \sum_{k=1}^K p_{uk} q_{ki}
 \end{equation}
 
 Za ocene iz učne množice $r_{ui}$ bi želeli, da je ta približek čim boljši, oziroma da je napaka, ki jo s tem približkom naredimo, čim manjša. Izračunajmo kvadrat napake za oceno stvari $i$ uporabnika $u$ in ga pomnožimo z $1\over 2$, da se nam kasneje pokrajša dvojka pri odvajanju:
@@ -264,7 +264,7 @@ Postopek iskanja razcepa matrike R na matriki P in Q, kot smo ga opisali zgoraj,
 Zgoraj opisan matrični razcep se lahko preveč prilagodi učnim podatkom, še posebej pri večjih vrednostih $K$. Tudi tu se preveliko prileganje odrazi v velikih vrednostih parametrov modela, torej velikih vrednostih elementov matrik P in Q. Preveliko prileganje preprečimo tako, da v našo ciljno funkcijo vključimo kaznovanje, ki izhaja iz velikosti parametrov:
 
 \begin{equation}
-{e'_{ui}}^2 = {1\over 2}(e_{ui}^2 + \eta {\bf p}_u {\bf p}_u^T + \eta {\bf q}_i {\bf q}_i^T)
+{e'_{ui}}^2 = {1\over 2}(e_{ui}^2 + \eta {\bf p}_u^T {\bf p}_u + \eta {\bf q}_i^T {\bf q}_i)
 \end{equation}
 
 Gradient, ki ga uporabimo pri metodi sestopa, dobimo s parcialnim odvajanjem zgornje kriterijske funkcije:

--- a/priporocanje.tex
+++ b/priporocanje.tex
@@ -215,19 +215,19 @@ Matrika $\rm P$ je matrika uporabniških profilov v latentnem prostoru filmov, t
 \begin{figure}[htbp]
 \begin{center}
 \includegraphics[width=7cm]{slike/latentni-faktorji.pdf}
-\caption{Predstavitev uporabnika $u$ z latetnim profilom ${\bf p}_u$ in stvari $i$ z latentnim profilom ${\bf q}_i$. Skalarni produkt latentnih profilov nam da približek za oceno stvari $i$ uporabnika $u$, torej $\hat{r_{ui}}={\bf p}_u^T {\bf q}_i$.}
+\caption{Predstavitev uporabnika $u$ z latetnim profilom ${\bf p}_u$ in stvari $i$ z latentnim profilom ${\bf q}_i$. Skalarni produkt latentnih profilov nam da približek za oceno stvari $i$ uporabnika $u$, torej $\hat{r}_{ui}={\bf p}_u^T {\bf q}_i$.}
 \label{f:latentni-faktorji}
 \end{center}
 \end{figure}
 
-Razcep matrike R na matriki P in Q bomo poiskali tako, da bosta matriki P in Q polni, torej, da bodo vse vrednosti teh dveh matrik določene. Prav zato bomo lahko s produktom latentnih profilov lahko poiskali vrednost $\hat{r_{ui}}$ za vsako kombinacijo uporabnika $u$ in stvari $i$. Ostane nam torej le še, da izračunamo razcep, oziroma določimo matriki P in Q.
+Razcep matrike R na matriki P in Q bomo poiskali tako, da bosta matriki P in Q polni, torej, da bodo vse vrednosti teh dveh matrik določene. Prav zato bomo lahko s produktom latentnih profilov lahko poiskali vrednost $\hat{r}_{ui}$ za vsako kombinacijo uporabnika $u$ in stvari $i$. Ostane nam torej le še, da izračunamo razcep, oziroma določimo matriki P in Q.
 
 \subsection{Matrični razcep}
 
 Z matrikami P in Q lahko izračunamo približek ocene za stvar $i$ uporabnika $u$, ki je:
 %
 \begin{equation}\label{eq:rui-latent}
-  \hat{r_{ui}}={\bf p}_u^T {\bf q}_i = \sum_{k=1}^K p_{uk} q_{ki}
+  \hat{r}_{ui}={\bf p}_u^T {\bf q}_i = \sum_{k=1}^K p_{uk} q_{ki}
 \end{equation}
 
 Za ocene iz učne množice $r_{ui}$ bi želeli, da je ta približek čim boljši, oziroma da je napaka, ki jo s tem približkom naredimo, čim manjša. Izračunajmo kvadrat napake za oceno stvari $i$ uporabnika $u$:


### PR DESCRIPTION
This commit includes:
- fixes of vector transposes
- fix of the error function, that had 1/2 in front. It is ok to use that form because of derivative, but later the error is included in some derivatives which have the error without 1/2. Problem fixed with an additional equation.
- Some style fixes of hats.

You can include those commits if you agree with changes. We can also discuss changes tomorrow. 